### PR TITLE
Google places toimimaan http/https-palvelimella

### DIFF
--- a/form.php
+++ b/form.php
@@ -532,7 +532,7 @@ function popup_dialog(url, on_close, dialog_title, event, width, height)
   $(document).ready(function() {
   var s = document.createElement("script");
     s.type = "text/javascript";
-    s.src  = "http://maps.googleapis.com/maps/api/js?sensor=false&libraries=places&callback=gmapsready";
+    s.src  = "//maps.googleapis.com/maps/api/js?sensor=false&libraries=places&callback=gmapsready";
     window.gmapsready = function(){
         initAddressAutocomplete("");
         initAddressAutocomplete("quick_");


### PR DESCRIPTION
Heipä hei,

Pienen korjauksen avulla googleapis / googleplaces toimii myös, jos käyttää https-protokollaa palvelimella. 
Muutoin tulee varoitus "blocked mixed content" (tms) eikä osoitelista toimi oikein.

Tuota src="//example.com/javascript.js" tyyliä kannattanee käyttää jatkossa, jos haluaa että ohjelmaa voi käyttää myös https protokollalla.

-Juho