### PR TITLE
add säästöpankki import statement preset

### DIFF
--- a/import.php
+++ b/import.php
@@ -589,7 +589,7 @@ class ImportFile
         ?>
 <script type="text/javascript">
 
-g_presets = <?php echo json_encode($this->presets) . ';'?>
+g_presets = <?php echo json_encode($this->presets, JSON_UNESCAPED_UNICODE) . ';'?>
 
 $(document).ready(function() {
   $('#imessage').ajaxStart(function() {
@@ -771,7 +771,7 @@ function add_mapping_columns(headings)
       td.appendChild(clone);
       tr.appendChild(td);
     }
-    var name = $("#preset").val();
+    var name = $("#preset option:selected").text();
     $.each(g_presets, function(index, preset) {
       if (preset['name'] == name) {
         $.each(preset['mappings'], function(element, value) {
@@ -785,7 +785,7 @@ function add_mapping_columns(headings)
 
 function select_preset()
 {
-  var name = $("#preset").val();
+  var name = $("#preset option:selected").text();
   $.each(g_presets, function(index, preset) {
     if (preset['name'] == name) {
       $.each(preset['selections'], function(element, value) {

--- a/import_statement.php
+++ b/import_statement.php
@@ -86,6 +86,28 @@ class ImportStatement extends ImportFile
                 ]
             ],
             [
+                'name' => 'Saastopankki',
+                'value' => 'Saastopankki',
+                'selections' => [
+                    'charset' => 1,
+                    'format' => 0,
+                    'field_delim' => 1,
+                    'enclosure_char' => 0,
+                    'row_delim' => 0,
+                    'date_format' => 0
+                ],
+                'mappings' => [
+                    'map_column0' => 1,
+                    'map_column4' => 2,
+                    'map_column3' => 3
+                ],
+                'values' => [
+                    'decimal_separator' => ',',
+                    'skip_rows' => '0'
+                ],
+            ],
+            [
+
                 'name' => 'KTL',
                 'value' => 'KTL',
                 'default_for' => 'fixed',
@@ -271,7 +293,8 @@ class ImportStatement extends ImportFile
             return $GLOBALS['locImportStatementFieldMissing'];
         }
 
-        $refnr = str_replace(' ', '', $row['refnr']);
+        $refnr = str_replace("'", '', $row['refnr']);
+        $refnr = str_replace(' ', '', $refnr);
         $refnr = ltrim($refnr, '0');
         $date = date(
             'Ymd',

--- a/import_statement.php
+++ b/import_statement.php
@@ -86,7 +86,7 @@ class ImportStatement extends ImportFile
                 ]
             ],
             [
-                'name' => 'Saastopankki',
+                'name' => 'Säästöpankki',
                 'value' => 'Saastopankki',
                 'selections' => [
                     'charset' => 1,
@@ -293,8 +293,7 @@ class ImportStatement extends ImportFile
             return $GLOBALS['locImportStatementFieldMissing'];
         }
 
-        $refnr = str_replace("'", '', $row['refnr']);
-        $refnr = str_replace(' ', '', $refnr);
+        $refnr = str_replace([' ', "'"], '', $row['refnr']);
         $refnr = ltrim($refnr, '0');
         $date = date(
             'Ymd',


### PR DESCRIPTION
Had to add the `str_replace("'", '', $row['refnr']);` because there is an actual apostrophe in the ref field.
**example csv**
```
"Datum";"Mottagare/betalare";"Förklaring";"Referens/meddelande";"Belopp"
"3.10.2016";"COMPANY A";"TILISIIRTO";"'2773";"-68,88"
"3.10.2016";"COMPANY B";"TILISIIRTO";"'00000000142000381374";"-239,82"
```

I didn't change the import preview though, so there it still shows fields with the apostrophe.