### PR TITLE
Dev

### DIFF
--- a/docker-nginx/Dockerfile
+++ b/docker-nginx/Dockerfile
@@ -1,0 +1,29 @@
+FROM alpine:latest
+
+RUN apk update
+RUN apk --no-cache add nginx  php83-mbstring php83-fpm php83-mysqli php82-mysqlnd php83-session curl unzip
+
+WORKDIR /work
+
+RUN curl -O https://labs.fi/files/mlinvoice-2.1.2.zip
+RUN unzip mlinvoice-2.1.2.zip
+RUN rm mlinvoice-2.1.2.zip
+
+RUN sed -ri \
+ -e "s/^user = nobody/user = www/" \
+ -e "s/^group = nobody/group = www/" /etc/php83/php-fpm.d/www.conf
+
+
+RUN addgroup -g 2024 www
+RUN adduser -S -D www -G www 
+
+RUN chown www:www /work/mlinvoice /work/mlinvoice/config.*
+
+COPY mlinvoice-nginx.conf /etc/nginx/nginx.conf
+COPY entrypoint /work/entrypoint
+
+EXPOSE 80
+
+HEALTHCHECK --interval=5m CMD curl -f http://localhost || exit 1
+
+ENTRYPOINT ["sh", "/work/entrypoint"]

--- a/docker-nginx/Dockerfile
+++ b/docker-nginx/Dockerfile
@@ -19,11 +19,11 @@ RUN adduser -S -D www -G www
 
 RUN chown www:www /work/mlinvoice /work/mlinvoice/config.*
 
+COPY config.php.sample /work/mlinvoice/config.php.sample
 COPY mlinvoice-nginx.conf /etc/nginx/nginx.conf
 COPY entrypoint /work/entrypoint
 
 EXPOSE 80
 
-HEALTHCHECK --interval=5m CMD curl -f http://localhost || exit 1
 
 ENTRYPOINT ["sh", "/work/entrypoint"]

--- a/docker-nginx/config.php.sample
+++ b/docker-nginx/config.php.sample
@@ -1,0 +1,19 @@
+<? 
+
+// ote config.php.sample:n alusta
+
+// Database server address
+// Tietokantapalvelimen osoite
+define('_DB_SERVER_', 'db');
+
+// Database server user id
+// Tunnus tietokantapalvelimelle
+define('_DB_USERNAME_', 'mlinvoice');
+
+// Database server password
+// Salasana tietokantapalvelimelle
+define('_DB_PASSWORD_', 'mlinvoice');
+
+// Database name
+// Tietokannan nimi
+define('_DB_NAME_', 'mlinvoice');

--- a/docker-nginx/docker-compose.yml
+++ b/docker-nginx/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  mlinvoice:
+    container_name: mlinvoice
+    build: .
+    ports:
+      - '8888:80'
+  db:
+    image: mysql:latest
+    restart: always
+    environment:
+      MYSQL_DATABASE: 'mlinvoice'
+      MYSQL_USER: 'mlinvoice'
+      MYSQL_PASSWORD: 'mlinvoice'
+      MYSQL_ROOT_PASSWORD: 'password'
+    volumes:
+      - my-db:/var/lib/mysql
+      - ./init-script.sql:/docker-entrypoint-initdb.d/init-script.sql
+volumes:
+  my-db:

--- a/docker-nginx/entrypoint
+++ b/docker-nginx/entrypoint
@@ -1,0 +1,3 @@
+#!/bin/sh
+php-fpm83 &
+nginx

--- a/docker-nginx/init-script.sql
+++ b/docker-nginx/init-script.sql
@@ -1,0 +1,3 @@
+CREATE DATABASE iF NOT EXISTS mlinvoice;
+GRANT ALL PRIVILEGES ON mlinvoice.* TO 'mlinvoice'@'%';
+ALTER USER 'mlinvoice' IDENTIFIED WITH mysql_native_password BY 'mlinvoice';

--- a/docker-nginx/mlinvoice-nginx.conf
+++ b/docker-nginx/mlinvoice-nginx.conf
@@ -1,0 +1,28 @@
+user nobody;
+worker_processes 2;
+error_log /dev/stdout;
+
+events {
+ worker_connections 1024;
+}
+http {
+ default_type application/octet-sream;
+ include mime.types;
+ server_names_hash_bucket_size 128;
+ client_max_body_size 3M;
+ charset utf-8;
+ server {
+  listen 80;
+  root /work/mlinvoice;
+  location / {
+   index index.php index.html;
+  }
+  location ~ \.php$ {
+   include fastcgi_params;
+   fastcgi_pass 127.0.0.1:9000;
+   fastcgi_index index.php;
+   fastcgi_param SCRIPT_FILENAME $document_root/$fastcgi_script_name;
+  }
+ }
+}
+daemon off;


### PR DESCRIPTION
# Käyttö
docker-composen dockerit saa toimintaan: (-d laittaa taustalle)

`host$ docker-compose up -d`

docker-composen dockerit voi ottaa pois käytöstä:

`host$ docker-compose down`

## docker-compose.yml
docker-compose mahdollistaa useiden eri konttien liittämistä yhteen / automatisoida toimintaa

## init-script.sql
sql:n pitää alustaa mlinvoicelle tietokanta ja antaa käyttäjälle tarvittavat oikeudet. Kun docker-compose:ssa laitettaan volume eli "kopioidaan" init-script.sql /docker-entrypoint-initdb.d/ hakemistoon niin se ajetaan automaattisesti kun docker-compose ajetaan ylös

## config.php.sample
Tästä on pieni ote miten tuo lähtee toimimaan docker-composen kanssa. Kun dockerit ovat samassa verkossa ne voi käyttää dockerin nimiä eli tuossa otetaan yhteys 'db' "koneeseen"

## Havaitut ongelmat
Kun ajetaan `docker-compose up` ensimmäisen kerran ongelmia ei sinäänsä ole. Ohjelman etusivu kyselee tarvittavat tiedot ja napeista pääsee eteenpäin. Ongelma tulee siitä kun laitetaan `docker-compose down` ja joskus myöhemmin `docker-compose up` ... se nimittäin tälläkin kertaa kyselee admin tunnuksen salasanaa jne... eli aloittaa prosessin alusta, koska config.php.sample tiedosto löytyy.

## Ratkaisu?
Olisiko tuohon ratkaisuna se, että käytetään config.php tiedostoa, johon tehdään asetukset. Itse tiedostoa ei muuteta ajossa vaan tiedostonimi pysyy samana. Ohjelma tekisi tarkistuksen löytyykö tunnukselle admin salasanaa ja jos löytyy niin hypätään käyttämään ohjelmaa eikä näytetä setup screeniä. Luulenpa että config säädöistä pääsisi varmaan joksikin aikaa tuolla (vois unohtaa muut dotenvit yms)

## Dockerfile
Tuosta voisi vielä poistaa curl:in ja laittaa zipin haun wget:llä. Wget nähtävästi tulee alpinen mukana. Voittaisi ~250 kilotavua :)